### PR TITLE
Fixed crash when server.hsconf does not have DBLogging info

### DIFF
--- a/OSDiagTool/OSDiagTool.csproj
+++ b/OSDiagTool/OSDiagTool.csproj
@@ -81,7 +81,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="ICSharpCode.SharpZipLib">
-      <HintPath>..\ICSharpCode.SharpZipLib.dll</HintPath>
+      <HintPath>..\..\..\..\Downloads\SharpZipLib-v1.3.3\lib\net45\ICSharpCode.SharpZipLib.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Diagnostics.Runtime, Version=1.0.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Diagnostics.Runtime.1.0.2\lib\net45\Microsoft.Diagnostics.Runtime.dll</HintPath>

--- a/OSDiagTool/OSDiagToolForm/OSDiagFormUI.cs
+++ b/OSDiagTool/OSDiagToolForm/OSDiagFormUI.cs
@@ -64,7 +64,16 @@ namespace OSDiagTool.OSDiagToolForm {
             this.cb_iisAccessLogs.Checked = configurations.osDiagToolConfigurations[OSDiagToolConfReader._l2_serverLogs][OSDiagToolConfReader._l3_iisLogs];
             this.nud_iisLogsNrDays.Value = configurations.IISLogsNrDays; // Number of days of IIS logs
 
-            this.cb_platformLogs.Checked = configurations.osDiagToolConfigurations[OSDiagToolConfReader._l2_platform][OSDiagToolConfReader._l3_platformLogs];
+            // Some server.hsconf don't have the DB Logging info. In that scenario, retrieving logs is not possible
+            if (Platform.ConfigFiles.ConfigFileReader.dbLoggingAvailable.Equals(true))
+            {
+                this.cb_platformLogs.Checked = configurations.osDiagToolConfigurations[OSDiagToolConfReader._l2_platform][OSDiagToolConfReader._l3_platformLogs];
+            } else
+            {
+                this.cb_platformLogs.Checked = false;
+                this.cb_platformLogs.Enabled = false;
+            }
+            
             this.nud_topLogs.Value = configurations.osLogTopRecords;
             this.cb_platformAndServerFiles.Checked = configurations.osDiagToolConfigurations[OSDiagToolConfReader._l2_platform][OSDiagToolConfReader._l3_platformAndServerConfigFiles];
 

--- a/OSDiagTool/Platform/ConfigFiles/ConfigFileReader.cs
+++ b/OSDiagTool/Platform/ConfigFiles/ConfigFileReader.cs
@@ -15,6 +15,8 @@ namespace OSDiagTool.Platform.ConfigFiles
         
         public static string IsEncryptedAttributeName = "encrypted";
         public static string ProviderKeyAttributeName = "ProviderKey";
+
+        public static bool dbLoggingAvailable = true;
         
         private ConfigFileInfo _dbPlatformDetails;
         private ConfigFileInfo _dbLoggingDetails;
@@ -73,7 +75,14 @@ namespace OSDiagTool.Platform.ConfigFiles
 
         private ConfigFileInfo ReadDbLoggingInfo(XElement root)
         {
-            return ReadSection(LoggingDatabaseConfigurationElement, root);
+            try
+            {
+                return ReadSection(LoggingDatabaseConfigurationElement, root);
+            } catch
+            {
+                dbLoggingAvailable = false;
+            }
+            return DBLoggingInfo;
         }
 
         private ConfigFileInfo ReadDbSessionInfo(XElement root)


### PR DESCRIPTION
Fixed crash when server.hsconf does not have DBLogging info